### PR TITLE
Developer dockerfile

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -8,7 +8,7 @@ substitutions:
   _BASE_IMAGE: panoptes-utils
   _IMAGE_NAME: panoptes-pipeline
   _REPO_URL: https://github.com/panoptes/panoptes-pipeline
-  _BUILD_DIR: panoptes-pipeline  
+  _BUILD_DIR: panoptes-pipeline
   _TAG: develop
 
 steps:
@@ -65,3 +65,20 @@ steps:
       - "--cache-from=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:${_TAG}"
       - "${_BUILD_DIR}"
     waitFor: [ "build-builder", "clone-repo" ]
+
+  # Build a developer version.
+  - name: "gcr.io/cloud-builders/docker"
+    id: "build-developer-images"
+    env:
+      - "DOCKER_CLI_EXPERIMENTAL=enabled"
+    args:
+      - "buildx"
+      - "build"
+      - "--push"
+      - "--platform=linux/amd64"
+      - "-f=docker/Dockerfile"
+      - "--build-arg=image_url=gcr.io/${PROJECT_ID}/panoptes-pocs:developer"
+      - "--tag=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:developer"
+      - "--cache-from=gcr.io/${PROJECT_ID}/${_IMAGE_NAME}:developer"
+      - "${_BUILD_DIR}"
+    waitFor: [ "build-images" ]


### PR DESCRIPTION
* Build a developer version based off `panoptes-pocs:developer`. Should ideally be based off a `panoptes-utils:developer` but okay for now.