### PR TITLE
Fix catalog match and BQ storage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-output
-notebooks

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ MANIFEST
 
 # Results
 output
+notebooks

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,4 +17,4 @@ gcloud run deploy "${TOPIC}" \
   --platform managed \
   --memory "8Gi" \
   --max-instances 100 \
-  --concurrency 2
+  --concurrency 1

--- a/src/panoptes/pipeline/utils/gcp/functions.py
+++ b/src/panoptes/pipeline/utils/gcp/functions.py
@@ -1,4 +1,3 @@
-import re
 from typing import Callable, Any
 
 
@@ -25,10 +24,6 @@ def cloud_function_entry_point(raw_message: dict,
 
     if bucket_path is None:
         raise Exception(f'No file requested')
-
-    # Make sure file has valid signature.
-    if re.search(r'\d{8}T\d{6}\.fits[.fz]+$', bucket_path) is None:
-        raise RuntimeError(f'Need a FITS file, got {bucket_path}')
 
     bucket = attributes['bucketId']
     public_bucket_path = f'https://storage.googleapis.com/{bucket}/{bucket_path}'

--- a/src/panoptes/pipeline/utils/gcp/functions.py
+++ b/src/panoptes/pipeline/utils/gcp/functions.py
@@ -27,7 +27,7 @@ def cloud_function_entry_point(raw_message: dict,
         raise Exception(f'No file requested')
 
     # Make sure file has valid signature.
-    if re.search(r'\d{8}T\d{6}\.fits[\.fz]+$', bucket_path) is None:
+    if re.search(r'\d{8}T\d{6}\.fits[.fz]+$', bucket_path) is None:
         raise RuntimeError(f'Need a FITS file, got {bucket_path}')
 
     bucket = attributes['bucketId']

--- a/src/panoptes/pipeline/utils/gcp/storage.py
+++ b/src/panoptes/pipeline/utils/gcp/storage.py
@@ -2,14 +2,17 @@ import os
 import shutil
 import subprocess
 
+import google.cloud.storage
 from google.cloud.storage import Bucket
 from loguru import logger
 from panoptes.utils.images import fits as fits_utils
 from tqdm.auto import tqdm
 
 
-def move_blob_to_bucket(blob_name: str, old_bucket: Bucket, new_bucket: Bucket,
-                        remove: bool = True):
+def move_blob_to_bucket(blob_name: str,
+                        old_bucket: Bucket,
+                        new_bucket: Bucket,
+                        remove: bool = True) -> google.cloud.storage.Blob:
     """Copy and optionally remove the blob from old to new bucket.
 
     Args:
@@ -20,15 +23,17 @@ def move_blob_to_bucket(blob_name: str, old_bucket: Bucket, new_bucket: Bucket,
             afterwards.
     """
     logger.info(f'Moving {blob_name} → {new_bucket}')
-    old_bucket.copy_blob(old_bucket.get_blob(blob_name), new_bucket)
+    new_blob = old_bucket.copy_blob(old_bucket.get_blob(blob_name), new_bucket)
     if remove:
         old_bucket.delete_blob(blob_name)
 
+    return new_blob
 
-def copy_blob_to_bucket(*args, **kwargs):
+
+def copy_blob_to_bucket(*args, **kwargs) -> google.cloud.storage.Blob:
     """A thin-wrapper around `move_blob_to_bucket` that sets `remove=False`."""
     kwargs['remove'] = False
-    move_blob_to_bucket(*args, **kwargs)
+    return move_blob_to_bucket(*args, **kwargs)
 
 
 def download_images(image_list, output_dir, overwrite=False, unpack=True, show_progress=True):

--- a/src/panoptes/pipeline/utils/metadata.py
+++ b/src/panoptes/pipeline/utils/metadata.py
@@ -475,6 +475,7 @@ def record_metadata(
         unit_collection: str = 'units',
         observation_collection: str = 'observations',
         image_collection: str = 'images',
+        force_new: bool = False,
         firestore_db: firestore.Client = None) -> str:
     """Add FITS header info to firestore_db.
 
@@ -510,7 +511,7 @@ def record_metadata(
 
         with suppress(KeyError, TypeError):
             image_status = image_doc_ref.get(['status']).to_dict()['status']
-            if ImageStatus[image_status] >= current_state:
+            if ImageStatus[image_status] >= current_state and force_new is False:
                 print(f'Skipping image with status of {ImageStatus[image_status].name}')
                 raise FileExistsError('Already processed')
 
@@ -521,22 +522,22 @@ def record_metadata(
         # Update unit info.
         unit_md['num_images'] = firestore.Increment(1)
         unit_md['total_exptime'] = firestore.Increment(sequence_md['exptime'])
-        unit_doc_ref.set(metadata['unit'], merge=True)
+        unit_doc_ref.set(unit_md, merge=True)
 
         # Update sequence info.
         sequence_md['num_images'] = firestore.Increment(1)
         sequence_md['total_exptime'] = firestore.Increment(sequence_md['exptime'])
-        seq_doc_ref.set(metadata['sequence'], merge=True)
+        seq_doc_ref.set(sequence_md, merge=True)
 
         # Update image info.
         print(f'Image metadata: {image_md!r}')
         image_md['status'] = current_state.name
         image_md['received_time'] = firestore.SERVER_TIMESTAMP
-        image_doc_ref.set(metadata['image'], merge=True)
+        image_doc_ref.set(image_md, merge=True)
 
     except Exception as e:
         print(f'Error in adding record: {traceback.format_exc()!r}')
         raise e
 
     print(f'Recorded metadata for {bucket_path} with {image_doc_ref.id=}')
-    return image_doc_ref.id
+    return image_doc_ref.path

--- a/src/panoptes/pipeline/utils/metadata.py
+++ b/src/panoptes/pipeline/utils/metadata.py
@@ -512,18 +512,21 @@ def record_metadata(
                 print(f'Skipping image with status of {ImageStatus[image_status].name}')
                 raise FileExistsError('Already processed')
 
-        # Add a units doc if it doesn't exist.
+        unit_md = metadata['unit']
+        sequence_md = metadata['sequence']
+        image_md = metadata['image']
+
+        # Update unit info.
+        unit_md['num_images'] = firestore.Increment(1)
+        unit_md['total_exptime'] = firestore.Increment(sequence_md['exptime'])
         unit_doc_ref.set(metadata['unit'], merge=True)
 
-        # Increment counters on sequence data and add time stamp.
-        sequence_md = metadata['sequence']
+        # Update sequence info.
         sequence_md['num_images'] = firestore.Increment(1)
         sequence_md['total_exptime'] = firestore.Increment(sequence_md['exptime'])
-
         seq_doc_ref.set(metadata['sequence'], merge=True)
 
-        # Add status to image data.
-        image_md = metadata['image']
+        # Update image info.
         print(f'Image metadata: {image_md!r}')
         image_md['status'] = current_state.name
         image_md['received_time'] = firestore.SERVER_TIMESTAMP

--- a/src/panoptes/pipeline/utils/metadata.py
+++ b/src/panoptes/pipeline/utils/metadata.py
@@ -488,6 +488,8 @@ def record_metadata(
     Raises:
         e: Description
     """
+    # TODO support batch operation.
+
     print(f'Recording header metadata in firestore for {bucket_path=}')
 
     firestore_db = firestore_db or firestore.Client()

--- a/src/panoptes/pipeline/utils/scripts/prepare.py
+++ b/src/panoptes/pipeline/utils/scripts/prepare.py
@@ -252,7 +252,8 @@ def main(
 
     # Mark which ones were duplicated.
     matched_sources['catalog_duplicate'] = False
-    matched_sources.picid.isin(matched_sources[duplicates].picid)['catalog_duplicate'] = True
+    dupes = matched_sources.picid.isin(matched_sources[duplicates].picid)
+    matched_sources[dupes]['catalog_duplicate_removed'] = True
 
     _print(f'Found {len(matched_sources)} matching sources after removing duplicates')
 

--- a/src/panoptes/pipeline/utils/scripts/prepare.py
+++ b/src/panoptes/pipeline/utils/scripts/prepare.py
@@ -172,6 +172,7 @@ def main(
 
     _print(f'Getting stars from catalog')
     solved_wcs0 = WCS(solved_headers)
+    # Todo: adjust vmag based on exptime.
     catalog_sources = sources.get_stars_from_wcs(solved_wcs0,
                                                  bq_client=bq_client,
                                                  bqstorage_client=bqstorage_client,

--- a/src/panoptes/pipeline/utils/scripts/prepare.py
+++ b/src/panoptes/pipeline/utils/scripts/prepare.py
@@ -103,7 +103,7 @@ def main(
                                         for bg
                                         in rgb_background]).sum(0).filled(0).astype(np.float32)
 
-    reduced_data = (data - combined_bg_data).data.astype('float')
+    reduced_data = (data - combined_bg_data).data.astype(np.float32)
 
     # Save reduced data and background.
     hdu0 = fits.PrimaryHDU(reduced_data, header=header)
@@ -246,8 +246,6 @@ def main(
     metadata_series = pd.json_normalize(metadata_headers, sep='_').iloc[0]
     matched_sources = matched_sources.assign(**metadata_series)
     matched_sources.set_index(['picid']).to_csv(matched_path, index=True)
-
-    # TODO send to bigquery.
 
     if use_firestore:
         try:

--- a/src/panoptes/pipeline/utils/scripts/prepare.py
+++ b/src/panoptes/pipeline/utils/scripts/prepare.py
@@ -24,7 +24,7 @@ from google.cloud import bigquery
 
 # Construct a BigQuery client object.
 client = bigquery.Client()
-bq_table_id = "panoptes-exp.observations.stars"
+bq_table_id = "panoptes-exp.observations.matched_sources"
 logger.remove()
 app = typer.Typer()
 

--- a/src/panoptes/pipeline/utils/scripts/prepare.py
+++ b/src/panoptes/pipeline/utils/scripts/prepare.py
@@ -40,7 +40,9 @@ def main(
         detection_threshold: float = 5.0,
         num_detect_pixels: int = 4,
         effective_gain: float = 1.5,
+        max_catalog_separation: int = 50,
         use_firestore: bool = False,
+        use_bigquery: bool = False,
         **kwargs
 ):
     if re.search(r'\d{8}T\d{6}\.fits[\.fz]+$', url) is None:
@@ -169,7 +171,7 @@ def main(
                                                 catalog_stars=catalog_sources,
                                                 ra_column='photutils_sky_centroid.ra',
                                                 dec_column='photutils_sky_centroid.dec',
-                                                max_separation_arcsec=None
+                                                max_separation_arcsec=max_catalog_separation
                                                 )
 
     # Drop matches near border
@@ -211,7 +213,7 @@ def main(
     # Puts metadata into better structures.
     metadata_headers = metadata.extract_metadata(header)
     metadata_headers['image']['num_sources'] = len(matched_sources)
-        
+
     metadata_json_path = output_dir / 'metadata.json'
     to_json(metadata_headers, filename=str(metadata_json_path))
     typer.echo(f'Saved metadata to {metadata_json_path}.')
@@ -225,6 +227,9 @@ def main(
             typer.echo(f'Saved metadata to firestore with id={image_id}')
         except Exception as e:
             typer.secho(f'Error recording metadata: {e!r}', fg=typer.colors.YELLOW)
+
+    if use_bigquery:
+        typer.echo('Pretend upload to bigquery here.')
 
     return metadata.ObservationPathInfo.from_fits_header(header).get_full_id(sep='/')
 

--- a/src/panoptes/pipeline/utils/scripts/prepare.py
+++ b/src/panoptes/pipeline/utils/scripts/prepare.py
@@ -236,12 +236,12 @@ def main(
 
     # Drop matches near border
     _print(f'Filtering sources near edges')
-    image_width, image_height = reduced_data.shape
+    image_height, image_width = reduced_data.shape
     matched_sources = matched_sources.query(
         'catalog_wcs_x_int > 10 and '
         f'catalog_wcs_x_int < {image_width - 10} and '
         'catalog_wcs_y_int > 10 and '
-        f'catalog_wcs_x_int < {image_height - 10}'
+        f'catalog_wcs_y_int < {image_height - 10}'
     )
     _print(f'Found {len(matched_sources)} matching sources')
 

--- a/src/panoptes/pipeline/utils/services/prepare.py
+++ b/src/panoptes/pipeline/utils/services/prepare.py
@@ -27,7 +27,9 @@ def index(raw_message: dict):
             full_image_id = cloud_function_entry_point(raw_message['message'],
                                                        prepare_main,
                                                        output_dir=tmp_dir,
-                                                       use_firestore=True)
+                                                       use_firestore=True,
+                                                       use_biqquery=True,
+                                                       )
         except Exception as e:
             print(f'Problem preparing an image: {e!r}')
             return {'success': False, 'error': f'{e!r}'}

--- a/src/panoptes/pipeline/utils/services/prepare.py
+++ b/src/panoptes/pipeline/utils/services/prepare.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from pathlib import Path
+import re
 
 from fastapi import FastAPI
 
@@ -8,10 +9,13 @@ from google.cloud import storage
 
 from panoptes.pipeline.utils.gcp.functions import cloud_function_entry_point
 from panoptes.pipeline.utils.scripts.prepare import main as prepare_main
+from panoptes.pipeline.utils.gcp.storage import move_blob_to_bucket
 
 app = FastAPI()
 storage_client = storage.Client()
 output_bucket = storage_client.get_bucket(os.getenv('OUTPUT_BUCKET', 'panoptes-images-processed'))
+incoming_bucket = storage_client.get_bucket(os.getenv('INPUT_BUCKET', 'panoptes-images-incoming'))
+error_bucket = storage_client.get_bucket(os.getenv('ERROR_BUCKET', 'panoptes-images-error'))
 
 
 @app.get('/')
@@ -22,15 +26,24 @@ async def root():
 @app.post('/prepare')
 def index(message_envelope: dict):
     print(f'Received {message_envelope}')
+
+    message = message_envelope['message']
+    bucket_path = message['attributes']['objectId']
+
     with tempfile.TemporaryDirectory() as tmp_dir:
         try:
-            full_image_id = cloud_function_entry_point(message_envelope['message'],
-                                                       prepare_main,
-                                                       output_dir=tmp_dir,
-                                                       )
+            # Make sure file has valid signature, i.e. we need a FITS here.
+            if re.search(r'\d{8}T\d{6}\.fits[.fz]+$', bucket_path) is None:
+                raise RuntimeError(f'Need a FITS file, got {bucket_path}')
+
+            full_image_id = cloud_function_entry_point(message, prepare_main, output_dir=tmp_dir)
         except Exception as e:
             print(f'Problem preparing an image: {e!r}')
-            return {'success': False, 'error': f'{e!r}'}
+
+            # Move to error bucket.
+            new_blob = move_blob_to_bucket(bucket_path, incoming_bucket, error_bucket)
+
+            return {'success': False, 'error': f'{e!r}', 'error_bucket_path': new_blob.path}
 
         # Upload assets to storage bucket.
         for f in Path(tmp_dir).glob('*'):

--- a/src/panoptes/pipeline/utils/services/prepare.py
+++ b/src/panoptes/pipeline/utils/services/prepare.py
@@ -20,19 +20,13 @@ async def root():
 
 
 @app.post('/prepare')
-def index(message_envelope: dict,
-          use_bigquery: bool = True,
-          use_firestore: bool = True,
-          force_new: bool = False):
+def index(message_envelope: dict):
     print(f'Received {message_envelope}')
     with tempfile.TemporaryDirectory() as tmp_dir:
         try:
             full_image_id = cloud_function_entry_point(message_envelope['message'],
                                                        prepare_main,
                                                        output_dir=tmp_dir,
-                                                       use_firestore=use_firestore,
-                                                       use_bigquery=use_bigquery,
-                                                       force_new=force_new,
                                                        )
         except Exception as e:
             print(f'Problem preparing an image: {e!r}')

--- a/src/panoptes/pipeline/utils/services/prepare.py
+++ b/src/panoptes/pipeline/utils/services/prepare.py
@@ -28,7 +28,7 @@ def index(raw_message: dict):
                                                        prepare_main,
                                                        output_dir=tmp_dir,
                                                        use_firestore=True,
-                                                       use_biqquery=True,
+                                                       use_bigquery=True,
                                                        )
         except Exception as e:
             print(f'Problem preparing an image: {e!r}')

--- a/src/panoptes/pipeline/utils/services/prepare.py
+++ b/src/panoptes/pipeline/utils/services/prepare.py
@@ -20,15 +20,19 @@ async def root():
 
 
 @app.post('/prepare')
-def index(message_envelope: dict):
+def index(message_envelope: dict,
+          use_bigquery: bool = True,
+          use_firestore: bool = True,
+          force_new: bool = False):
     print(f'Received {message_envelope}')
     with tempfile.TemporaryDirectory() as tmp_dir:
         try:
             full_image_id = cloud_function_entry_point(message_envelope['message'],
                                                        prepare_main,
                                                        output_dir=tmp_dir,
-                                                       use_firestore=True,
-                                                       use_bigquery=True,
+                                                       use_firestore=use_firestore,
+                                                       use_bigquery=use_bigquery,
+                                                       force_new=force_new,
                                                        )
         except Exception as e:
             print(f'Problem preparing an image: {e!r}')

--- a/src/panoptes/pipeline/utils/services/prepare.py
+++ b/src/panoptes/pipeline/utils/services/prepare.py
@@ -20,11 +20,11 @@ async def root():
 
 
 @app.post('/prepare')
-def index(raw_message: dict):
-    print(f'Received {raw_message}')
+def index(message_envelope: dict):
+    print(f'Received {message_envelope}')
     with tempfile.TemporaryDirectory() as tmp_dir:
         try:
-            full_image_id = cloud_function_entry_point(raw_message['message'],
+            full_image_id = cloud_function_entry_point(message_envelope['message'],
                                                        prepare_main,
                                                        output_dir=tmp_dir,
                                                        use_firestore=True,

--- a/src/panoptes/pipeline/utils/sources.py
+++ b/src/panoptes/pipeline/utils/sources.py
@@ -38,7 +38,6 @@ def get_stars(
         shape=None,
         vmag_min=4,
         vmag_max=17,
-        numcont=4,
         bq_client=None,
         bqstorage_client=None,
         column_mapping=None,

--- a/src/panoptes/pipeline/utils/sources.py
+++ b/src/panoptes/pipeline/utils/sources.py
@@ -22,10 +22,6 @@ def get_stars_from_wcs(wcs: WCS, **kwargs) -> pandas.DataFrame:
     # Add the first entry to the end to complete polygon
     wcs_footprint.append(wcs_footprint[0])
 
-    # The longitude must be in -180 to 180 range
-    # scale_func = np.vectorize(lambda x: (x + 180) % 360 - 180)
-    # wcs_footprint = scale_func(wcs_footprint)
-
     poly = ','.join([f'{c[0]:.05} {c[1]:.05f}' for c in wcs_footprint])
 
     logger.debug(f'Using poly={poly} for get_stars')

--- a/src/panoptes/pipeline/utils/sources.py
+++ b/src/panoptes/pipeline/utils/sources.py
@@ -90,6 +90,12 @@ def get_stars(
 
     column_mapping_str = ', '.join([f'{k} as {v}' for k, v in column_mapping.items()])
 
+    # The Right Ascension can wrap around from 360° to 0°, so we have to specifically check.
+    if shape['ra_min'] > shape['ra_max']:
+        ra_constraint = 'OR'
+    else:
+        ra_constraint = 'AND'
+
     # Note that for how the BigQuery partition works, we need the partition one step
     # below the requested Vmag_max.
     sql = f"""
@@ -97,7 +103,7 @@ def get_stars(
     FROM catalog.pic
     WHERE
         dec >= {shape['dec_min']} AND dec <= {shape['dec_max']} AND
-        ra >= {shape['ra_min']} AND ra <= {shape['ra_max']} AND
+        ra >= {shape["ra_min"]} {ra_constraint} ra <= {shape["ra_max"]} AND
         vmag_partition BETWEEN {vmag_min} AND {vmag_max - 1}
     """
 


### PR DESCRIPTION
* Store matched sources, including metadata, directly in BQ.
* Vmag limits for catalog lookup changed to 6 - 14. Ideally this should adjust based on exptime.
* Default `50 arcsec` separation constraint for matched sources.
* Deal with duplicates slightly better.
* Column names sorted.
* FITS should be `float32` for calibrated.